### PR TITLE
Improve unittest using setUp and tearDown, small change for defining model only once

### DIFF
--- a/image_sorter.py
+++ b/image_sorter.py
@@ -19,6 +19,10 @@ class ImageSorter:
         if not os.path.isdir(output_path):
             os.mkdir(output_path)
 
+        # For speed optimization, all algorithms are defined here
+        self.backSub = cv.createBackgroundSubtractorMOG2()
+        self.CNN = CNNModel()
+
     def read_images(self):
         data_path = self.input_path + "/*"
         files = glob.glob(data_path)
@@ -43,18 +47,16 @@ class ImageSorter:
         return distance
 
     def apply_CNN(self, list_of_images):
-        CNN = CNNModel()
-        list_of_masks = CNN.apply_model(list_of_images)
+        list_of_masks = self.CNN.apply_model(list_of_images)
         return list_of_masks
 
     def substract_background(self, list_of_images, background_sub_iterations = 5):
-        backSub = cv.createBackgroundSubtractorMOG2()
         list_of_edited_images = []
         for i in range(background_sub_iterations):
             for frame in list_of_images:
-                _ = backSub.apply(frame)
+                _ = self.backSub.apply(frame)
         for frame in list_of_images:
-            mask = backSub.apply(frame)
+            mask = self.backSub.apply(frame)
             new_frame = cv.bitwise_and(frame, frame, mask=mask)
             list_of_edited_images.append(new_frame)
         return list_of_edited_images
@@ -73,7 +75,7 @@ class ImageSorter:
         list_of_images = list(zip(images_to_save, list_of_images))
         main_image = list_of_images.pop()
         image_index = 0
-        image_name = self.output_path + "/image_{}.jpg".format(image_index)
+        image_name = os.path.join(self.output_path, f"image_{image_index}.jpg")
         pyplot.imsave(image_name, main_image[0])
         while(list_of_images):
             current_image = list_of_images[0]
@@ -87,6 +89,5 @@ class ImageSorter:
                     closest_image_index = index
             main_image = list_of_images.pop(closest_image_index)
             image_index = image_index + 1
-            image_name = self.output_path + "/image_{}.jpg".format(image_index)
+            image_name = os.path.join(self.output_path, f"image_{image_index}.jpg")
             pyplot.imsave(image_name, main_image[0])
-

--- a/test_project.py
+++ b/test_project.py
@@ -1,44 +1,38 @@
+import os
 import unittest
 import numpy as np
-import os
 from matplotlib import pyplot
+from image_sorter import ImageSorter
+
 
 class TestImageSorter(unittest.TestCase):
-    def create_ImageSorter(self):
+    def setUp(self):
         os.mkdir("tempInput")
         image = np.random.rand(50,50)
         pyplot.imsave("tempInput/image_1.jpg", image)
         os.mkdir("tempOutput")
-        from image_sorter import ImageSorter
         return ImageSorter("tempInput", "tempOutput")
 
-    def remove_temporary_directories(self):
+    def tearDown(self):
         os.remove("tempInput/image_1.jpg")
         os.rmdir("tempInput")
         os.rmdir("tempOutput")
 
     def test_compare_two_images_L2(self):
-        ImageSorter = self.create_ImageSorter()
         image_1 = np.random.rand(50,50)
         image_2 = np.random.rand(50,50)
         score_1 = ImageSorter.compare_two_images_L2(image_1, image_1)
         score_2 = ImageSorter.compare_two_images_L2(image_1, image_2)
         self.assertTrue(score_1<score_2)
-        self.remove_temporary_directories()
 
     def test_compare_two_images_cosine(self):
-        ImageSorter = self.create_ImageSorter()
         image_1 = np.random.rand(50,50)
         image_2 = np.random.rand(50,50)
         score_1 = ImageSorter.compare_two_images_cosine(image_1, image_1)
         score_2 = ImageSorter.compare_two_images_cosine(image_1, image_2)
         self.assertTrue(score_1<score_2)
-        self.remove_temporary_directories()
 
     def test_substract_background(self):
-        ImageSorter = self.create_ImageSorter()
         image_1 = np.random.rand(50,50)
         mask = ImageSorter.substract_background([image_1])
         self.assertTrue(not np.any(mask))
-        self.remove_temporary_directories()
-


### PR DESCRIPTION
Hello, 
I run this code on my computer and did some changes in the code :
  - Using set Up and tearDown, the unittest can be written without calling create_ImageSorter and remove_temporary_directories in every test.
  - I think it's better to instantiate the models only once in the __init__ function.
  - os.path.join is better when merging folder names
  - I changed the .format to f-string, because now python 3.6 is standard and it's clearer (and faster) this way. Feel free to undo the change if you're using python < 3.6

Best regards